### PR TITLE
REFACTOR: @import Foundation

### DIFF
--- a/ActiveSupportInflector.h
+++ b/ActiveSupportInflector.h
@@ -3,6 +3,8 @@
 //  ActiveSupportInflector
 //
 
+@import Foundation;
+
 @interface ActiveSupportInflector : NSObject {
   NSMutableSet* uncountableWords;
   NSMutableArray* pluralRules;


### PR DESCRIPTION
As of Xcode 6.2 new projects do not come with a pre-compliled header file. Importing Foundation will ease the set up process for those with newer projects without requiring changes for existing users. Thanks for considering the change!
